### PR TITLE
Improve CompostBinRecipe#getRecipe loading time

### DIFF
--- a/src/main/java/com/codetaylor/mc/pyrotech/modules/tech/basic/recipe/CompostBinRecipe.java
+++ b/src/main/java/com/codetaylor/mc/pyrotech/modules/tech/basic/recipe/CompostBinRecipe.java
@@ -3,9 +3,11 @@ package com.codetaylor.mc.pyrotech.modules.tech.basic.recipe;
 import com.codetaylor.mc.athenaeum.util.RecipeHelper;
 import com.codetaylor.mc.pyrotech.library.CompostBinRecipeBase;
 import com.codetaylor.mc.pyrotech.modules.tech.basic.ModuleTechBasic;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.registries.IForgeRegistryModifiable;
 
 import javax.annotation.Nullable;
@@ -20,24 +22,39 @@ public class CompostBinRecipe
   @Nullable
   public static CompostBinRecipe getRecipe(ItemStack input) {
 
-    for (CompostBinRecipe recipe : ModuleTechBasic.Registries.COMPOST_BIN_RECIPE) {
-
-      if (recipe.matches(input)) {
-        return recipe;
-      }
-    }
-
-    return null;
+    Item inputItem = input.getItem();
+    ResourceLocation registryName = inputItem.getRegistryName();
+    if (registryName == null) return null;
+    String resourceDomain = registryName.getResourceDomain().toLowerCase();
+    String resourcePath = registryName.getResourcePath().toLowerCase();
+    ResourceLocation resourceLocation = new ResourceLocation(ModuleTechBasic.MOD_ID, resourceDomain + "_" + resourcePath + "_" + input.getMetadata());
+    ResourceLocation resourceLocationWild = new ResourceLocation(ModuleTechBasic.MOD_ID, resourceDomain + "_" + resourcePath + "_" + OreDictionary.WILDCARD_VALUE);
+    
+    CompostBinRecipe recipe = ModuleTechBasic.Registries.COMPOST_BIN_RECIPE.getValue(resourceLocation);
+    return (recipe != null) ? recipe : ModuleTechBasic.Registries.COMPOST_BIN_RECIPE.getValue(resourceLocationWild);
   }
 
   @Nullable
   public static CompostBinRecipe getRecipe(ItemStack input, ItemStack output) {
 
-    for (CompostBinRecipe recipe : ModuleTechBasic.Registries.COMPOST_BIN_RECIPE) {
+    Item inputItem = input.getItem();
+    ResourceLocation registryName = inputItem.getRegistryName();
+    if (registryName == null) return null;
+    String resourceDomain = registryName.getResourceDomain().toLowerCase();
+    String resourcePath = registryName.getResourcePath().toLowerCase();
+    ResourceLocation resourceLocation = new ResourceLocation(ModuleTechBasic.MOD_ID, resourceDomain + "_" + resourcePath + "_" + input.getMetadata());
+    ResourceLocation resourceLocationWild = new ResourceLocation(ModuleTechBasic.MOD_ID, resourceDomain + "_" + resourcePath + "_" + OreDictionary.WILDCARD_VALUE);
 
-      if (recipe.matches(input, output)) {
-        return recipe;
-      }
+    CompostBinRecipe recipe = ModuleTechBasic.Registries.COMPOST_BIN_RECIPE.getValue(resourceLocation);
+
+    if (recipe != null && recipe.matches(input, output)) {
+      return recipe;
+    }
+
+    recipe = ModuleTechBasic.Registries.COMPOST_BIN_RECIPE.getValue(resourceLocationWild);
+
+    if (recipe != null && recipe.matches(input, output)) {
+      return recipe;
     }
 
     return null;


### PR DESCRIPTION
Replaces a for loop with a registry getValue call.

If a modpack has lots of food items, there can be a lot of values in the CompostBinRecipe registry. Since the CompostBinRecipe.getRecipe call is called for every food item, the method alone can take a while to execute - to add to that, the getRecipe method is called in the TooltipEvent, which is called for every item. This can produce an extra loading time of about 40 seconds as it iterates over every food value for every item in the game.
<img width="818" alt="Screen Shot 2021-12-31 at 10 08 21 PM" src="https://user-images.githubusercontent.com/32407067/147843772-21ab63ad-02ba-4308-8df6-b7365a8318b8.png">

By replacing the costly for loop with a simpler getValue call, the method's execution saves a lot of processing.