### PR TITLE
Make Bloomery recipe & WitherForgeRecipe public

### DIFF
--- a/src/main/java/com/codetaylor/mc/pyrotech/modules/tech/bloomery/recipe/BloomeryRecipe.java
+++ b/src/main/java/com/codetaylor/mc/pyrotech/modules/tech/bloomery/recipe/BloomeryRecipe.java
@@ -29,7 +29,7 @@ public class BloomeryRecipe
     return RecipeHelper.removeRecipesByOutput(ModuleTechBloomery.Registries.BLOOMERY_RECIPE, output);
   }
 
-  /* package */ BloomeryRecipe(
+  public BloomeryRecipe(
       ItemStack output,
       Ingredient input,
       int burnTimeTicks,

--- a/src/main/java/com/codetaylor/mc/pyrotech/modules/tech/bloomery/recipe/WitherForgeRecipe.java
+++ b/src/main/java/com/codetaylor/mc/pyrotech/modules/tech/bloomery/recipe/WitherForgeRecipe.java
@@ -29,7 +29,7 @@ public class WitherForgeRecipe
     return RecipeHelper.removeRecipesByOutput(ModuleTechBloomery.Registries.WITHER_FORGE_RECIPE, output);
   }
 
-  /* package */ WitherForgeRecipe(
+  public WitherForgeRecipe(
       ItemStack output,
       Ingredient input,
       int burnTimeTicks,


### PR DESCRIPTION
Hello, 
I understand why these constructors are `package-private` since you should use the recipe builders.
Yet, the reason for making these constructors public is to provide compatibility for the GroovyScript mod to add these recipes using its recipe builders.
All the best, teksturepako